### PR TITLE
[#XGB-142] Add note on chrome CSP bug with websockets

### DIFF
--- a/docs/SECURITY.adoc
+++ b/docs/SECURITY.adoc
@@ -11,8 +11,12 @@ The following configuration is the most restrictive policy that is required by t
 |===
 |Header |Value |Notes
 
-|`Content-Security-Policy` |`default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self' bosh.example.com; img-src 'self' data:; style-src 'self' 'unsafe-inline';` | `unsafe-inline` is required by the angular framework.
-|`Access-Control-Allow-Origin` |`xgb.example.com bosh.example.com`|``
+|`Content-Security-Policy` |
+`default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self' bosh.example.com; img-src 'self' data:; style-src 'self' 'unsafe-inline';` |
+`unsafe-inline` is required by the angular framework.
+
+Note that as of 2018-04-28 https://bugs.chromium.org/p/chromium/issues/detail?id=815142[Chrome has an open issue] that requires explicit listing of websocket domains if needed.
+|`Access-Control-Allow-Origin` |`xgb.example.com bosh.example.com`|
 |===
 
 == XMPP Server


### PR DESCRIPTION
This issue is a [bug in chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=815142) and could also be a problem if used with XMPP over WebSockets, which I noted in the security documentation.

I did not add the CSP-option to our nginx stack configuration, as we only use websockets for the angular live reloading, which should also work with http-long-polling (socket.io).